### PR TITLE
added in variant for MSVC with noexcept

### DIFF
--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -41,8 +41,14 @@
     BOOST_PP_EXPAND( BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS BOOST_TYPE_INDEX_CTTI_USER_DEFINED_PARSING )
 
 #elif defined(_MSC_VER)
+
+#if defined (BOOST_NO_CXX11_NOEXCEPT)
     // sizeof("const char *__cdecl boost::detail::ctti<") - 1, sizeof(">::n(void)") - 1
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(40, 10, false, "")
+#else
+    // sizeof("const char *__cdecl boost::detail::ctti<") - 1, sizeof(" >::n(void) noexcept") - 1
+    BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(40, 20, false, "")
+#endif
 #elif defined(__clang__) && defined(__APPLE__)
     // Someone made __clang_major__ equal to LLVM version rather than compiler version
     // on APPLE platform.


### PR DESCRIPTION
I added in a variant for MSVC with noexcept, because the __FUNCNAME__ is different. 

Is it acutally a requirement of the library, that `pretty_name()` is equal for ctti and stl? 