### PR TITLE
Add support for gcc 6

### DIFF
--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -285,6 +285,27 @@ struct ctti {
 #endif
 };
 
+#if !defined(BOOST_NO_CXX14_CONSTEXPR)
+template<typename T, typename U>
+constexpr bool operator==(ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) == 0;}
+
+template<typename T, typename U>
+constexpr bool operator!=(ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) != 0;}
+
+template<typename T, typename U>
+constexpr bool operator> (ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) < 0;}
+
+template<typename T, typename U>
+constexpr bool operator< (ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) > 0;}
+
+template<typename T, typename U>
+constexpr bool operator>=(ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) >= 0;}
+
+template<typename T, typename U>
+constexpr bool operator<=(ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) <= 0;}
+
+#endif
+
 }} // namespace boost::detail
 
 #endif // BOOST_TYPE_INDEX_DETAIL_COMPILE_TIME_TYPE_INFO_HPP

--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -63,7 +63,7 @@
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(87, 1, false, "")
 #elif defined(__GNUC__) && !defined(BOOST_NO_CXX14_CONSTEXPR) && (__GNUC__ >= 6)
     // sizeof("static const char* boost::detail::ctti<T>::n() [with T = ") - 1, sizeof("]") - 1
-    BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(81, 1, false, "]")
+    BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(93, 1, false, "]")
 #elif defined(__GNUC__) && defined(BOOST_NO_CXX14_CONSTEXPR) && (__GNUC__ < 6)
     // sizeof("static const char* boost::detail::ctti<T>::n() [with T = ") - 1, sizeof("]") - 1
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(57, 1, false, "")

--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -285,27 +285,6 @@ struct ctti {
 #endif
 };
 
-#if !defined(BOOST_NO_CXX14_CONSTEXPR)
-template<typename T, typename U>
-constexpr bool operator==(ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) == 0;}
-
-template<typename T, typename U>
-constexpr bool operator!=(ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) != 0;}
-
-template<typename T, typename U>
-constexpr bool operator> (ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) > 0;}
-
-template<typename T, typename U>
-constexpr bool operator< (ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) < 0;}
-
-template<typename T, typename U>
-constexpr bool operator>=(ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) >= 0;}
-
-template<typename T, typename U>
-constexpr bool operator<=(ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) <= 0;}
-
-#endif
-
 }} // namespace boost::detail
 
 #endif // BOOST_TYPE_INDEX_DETAIL_COMPILE_TIME_TYPE_INFO_HPP

--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -32,7 +32,6 @@
     /**/
 /// @endcond
 
-
 #if defined(BOOST_TYPE_INDEX_DOXYGEN_INVOKED)
     /* Nothing to document. All the macro docs are moved to <boost/type_index.hpp> */
 #elif defined(BOOST_TYPE_INDEX_CTTI_USER_DEFINED_PARSING)
@@ -59,10 +58,13 @@
     // sizeof("static const char *boost::detail::ctti<") - 1, sizeof("]") - 1, true, "int>::n() [T = int"
     // note: checked on 3.1, 3.4
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(39, 1, true, "T = ")
-#elif defined(__GNUC__) && !defined(BOOST_NO_CXX14_CONSTEXPR)
+#elif defined(__GNUC__) && !defined(BOOST_NO_CXX14_CONSTEXPR) && (__GNUC__ < 6)
     // sizeof("static contexpr char boost::detail::ctti<T>::s() [with long unsigned int I = 0ul; T = ") - 1, sizeof("]") - 1
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(87, 1, false, "")
-#elif defined(__GNUC__) && defined(BOOST_NO_CXX14_CONSTEXPR)
+#elif defined(__GNUC__) && !defined(BOOST_NO_CXX14_CONSTEXPR) && (__GNUC__ >= 6)
+    // sizeof("static const char* boost::detail::ctti<T>::n() [with T = ") - 1, sizeof("]") - 1
+    BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(81, 1, false, "]")
+#elif defined(__GNUC__) && defined(BOOST_NO_CXX14_CONSTEXPR) && (__GNUC__ < 6)
     // sizeof("static const char* boost::detail::ctti<T>::n() [with T = ") - 1, sizeof("]") - 1
     BOOST_TYPE_INDEX_REGISTER_CTTI_PARSING_PARAMS(57, 1, false, "")
 #else

--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -293,10 +293,10 @@ template<typename T, typename U>
 constexpr bool operator!=(ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) != 0;}
 
 template<typename T, typename U>
-constexpr bool operator> (ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) < 0;}
+constexpr bool operator> (ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) > 0;}
 
 template<typename T, typename U>
-constexpr bool operator< (ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) > 0;}
+constexpr bool operator< (ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) < 0;}
 
 template<typename T, typename U>
 constexpr bool operator>=(ctti<T>, ctti<U>) {return ::boost::typeindex::detail::constexpr_strcmp(ctti<T>::n(), ctti<U>::n()) >= 0;}


### PR DESCRIPTION
Added support for gcc 6. I also added comparison operators for `boost::detail::ctti` to be used with boost.hana.
