### PR TITLE
Include <boost/functional/hash.hpp> if required

### DIFF
--- a/include/boost/type_index/stl_type_index.hpp
+++ b/include/boost/type_index/stl_type_index.hpp
@@ -40,6 +40,10 @@
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/or.hpp>
 
+#if !(_MSC_VER > 1600 || (__GNUC__ == 4 && __GNUC_MINOR__ > 5 && defined(__GXX_EXPERIMENTAL_CXX0X__)))
+#   include <boost/functional/hash/hash.hpp>
+#endif
+
 #if (defined(__EDG_VERSION__) && __EDG_VERSION__ < 245) \
         || (defined(__sgi) && defined(_COMPILER_VERSION) && _COMPILER_VERSION <= 744)
 #   include <boost/type_traits/is_signed.hpp>


### PR DESCRIPTION
With gcc 6.3.0, the following program fails to link:
```
#include <boost/type_index.hpp>
int main() {
    return boost::typeindex::type_id<int>().hash_code();
}
In function `main':
main.cpp:(.text.startup+0x23): undefined reference to `unsigned long boost::hash_range<char const*>(char const*, char const*)'
collect2: error: ld returned 1 exit status
```
Example: http://coliru.stacked-crooked.com/a/0b04de325c6f6529

Workaround is to `#include <boost/functional/hash.hpp>` before/after including Boost.TypeIndex headers.
