### PR TITLE
Make ctti_type_index::name() pretty by default since C++14

### DIFF
--- a/doc/type_index.qbk
+++ b/doc/type_index.qbk
@@ -14,12 +14,12 @@
 Sometimes getting and storing information about a type at runtime is required. For such cases a construction like `&typeid(T)` or C++11 class `std::type_index` is usually used, which is where problems start:
 
 * `typeid(T)` and `std::type_index` require Run Time Type Info (RTTI)
-* some implementations of `typeid(T)` erroneously do not strip const, volatile and references from type
-* some compilers have bugs and do not correctly compare `std::type_info` objects across shared libraries
-* only a few implementations of Standard Library currently provide `std::type_index`
-* no easy way to store type info without stripping const, volatile and references
+* no easy way to work with type info at compile time, no way to get the type name at compile time
 * no nice and portable way to get human readable type names
 * no way to easily make your own type info class
+* some implementations have bugs and do not correctly compare `std::type_info` objects across shared libraries
+* no easy way to store type info without stripping `const`, `volatile` and references
+* some implementations of `typeid(T)` erroneously do not strip `const`, `volatile` and references from type
 
 Boost.TypeIndex library was designed to work around all those issues.
 
@@ -360,19 +360,26 @@ so prefer using `stl_type_index` type when possible.
 
 [endsect]
 
-[section Code bloat]
+[section:code_bloat Code bloat]
 
 Without RTTI TypeIndex library will switch from using `boost::typeindex::stl_type_index` class to
 `boost::typeindex::ctti_type_index`. `boost::typeindex::ctti_type_index` uses macro for getting full
 text representation of function name for each type that is passed to `type_id()` and
 `type_id_with_cvr()` functions.
 
-This leads to big strings in binary file:
+This leads to big strings in binary file in C++11 mode:
 ```
 static const char* boost::detail::ctti<T>::n() [with T = int]
 static const char* boost::detail::ctti<T>::n() [with T = user_defined_type]
 ```
-While using RTTI, you'll get the following (more compact) string in binary file:
+
+Starting from C++14 the strings are much shorter and contain only the actual type name:
+```
+int
+user_defined_type
+```
+
+With RTTI, you'll always get the short strings in binary files:
 
 ```
 i
@@ -422,17 +429,19 @@ function signature including template parameters.
 
 [endsect]
 
-[section Fixing pretty_name() output]
+[section Fixing pretty_name() and name() output]
 
-If the output of `boost::typeindex::ctti_type_index::type_id<int>().name()` 
+If the output of `boost::typeindex::ctti_type_index::type_id<int>().pretty_name()`
+
 * returns not just `int` but also a lot of text around the `int` 
 * or does not return type at all
+
 then you are using a compiler that was not tested with this library and you need to setup the
 [macroref BOOST_TYPE_INDEX_CTTI_USER_DEFINED_PARSING] macro.
 
 Here is a short instruction:
 
-# get the output of `boost::typeindex::ctti_type_index::type_id<int>().name()`
+# get the output of `boost::typeindex::ctti_type_index::type_id<int>().pretty_name()`
 # define [macroref BOOST_TYPE_INDEX_CTTI_USER_DEFINED_PARSING] to 
 `(skip_at_begin, skip_at_end, false, "")`, where
     * `skip_at_begin` is equal to characters count before the first occurrence of `int` in output 
@@ -451,7 +460,7 @@ parameters provided to `BOOST_TYPE_INDEX_CTTI_USER_DEFINED_PARSING` macro.
 Consider the following example:
 
 `boost::typeindex::ctti_type_index::type_id<int>().raw_name()` returns
-"const char *__cdecl boost::detail::ctti<int>::n(void)". Then you shall set
+`"const char *__cdecl boost::detail::ctti<int>::n(void)"`. Then you shall set
 `skip_at_begin` to `sizeof("const char *__cdecl boost::detail::ctti<") - 1`
 and `skip_at_end` to `sizeof(">::n(void)") - 1`.
 

--- a/doc/type_index.qbk
+++ b/doc/type_index.qbk
@@ -287,7 +287,9 @@ Issues with cross module type comparison on a bugged compilers are bypassed by d
 
 [section Making a custom type_index]
 
-Sometimes there may be a need to create your own type info system. This may be useful if you wish to store some more info about types (PODness, size of a type, pointers to common functions...) or if you have an idea of a more compact types representations.
+Sometimes there may be a need to create your own type info system. This may be useful if you wish to store some
+more info about types (trivial copiability, size of a type, pointers to common functions...) or if you have an
+idea of a more compact types representations.
 
 [import ../examples/user_defined_typeinfo.hpp]
 [import ../examples/user_defined_typeinfo.cpp]
@@ -324,9 +326,10 @@ make the `Boost::type_index` CMake target provide it. After that an explicit usa
 [import ../modules/usage_sample.cpp]
 [type_index_module_example]
 
-The `Boost::type_index` CMake target gives an ability to mix includes and imports of the library in different translation units. Moreover,
-if `BOOST_USE_MODULES` macro is defined then all the `boost/type_index/...` includes implicilty do `import boost.type_index;` to give all the
-benifits of modules without changing the existing code.
+The `Boost::type_index` CMake target gives an ability to mix includes and imports of the library in different
+translation units. Moreover, if `BOOST_USE_MODULES` macro is defined then all the `boost/type_index/...`
+includes implicitly do `import boost.type_index;` to give all the benefits of modules without changing the
+existing code.
 
 [note For better compile times make sure that `import std;` is available when building the `boost.type_index` module (in CMake logs there should be
       a 'Using `import std;`' message). ]
@@ -351,12 +354,14 @@ clang++ -std=c++20 -fmodule-file=boost_type_index.pcm boost_type_index.pcm usage
 
 [section Space and Performance]
 
-* `ctti_type_index` uses macro for getting full text representation of function name which could lead to code bloat,
-so prefer using `stl_type_index` type when possible.
+* `ctti_type_index` uses macro for getting full text representation of function name which could lead to code bloat
+  in C++11, so prefer using `stl_type_index` type when possible.
 * All the type_index classes hold a single pointer and are fast to copy.
-* Calls to `const char* raw_name()` do not require dynamic memory allocation and usually just return a pointer to an array of chars in a read-only section of the binary image.
+* Calls to `const char* raw_name()` do not require dynamic memory allocation and usually just return a pointer
+  to an array of chars in a read-only section of the binary image.
 * Comparison operators are optimized as much as possible and execute a single `std::strcmp` in worst case.
-* Calls to `std::string pretty_name()` usually require dynamic memory allocation and some computations, so they are not recommended for usage in performance critical sections.
+* Calls to `std::string pretty_name()` usually require dynamic memory allocation and some computations,
+  so they are not recommended for usage in performance critical sections.
 
 [endsect]
 

--- a/include/boost/type_index/ctti_type_index.hpp
+++ b/include/boost/type_index/ctti_type_index.hpp
@@ -10,10 +10,11 @@
 #define BOOST_TYPE_INDEX_CTTI_TYPE_INDEX_HPP
 
 /// \file ctti_type_index.hpp
-/// \brief Contains boost::typeindex::ctti_type_index class that is constexpr if C++14 constexpr is supported by compiler.
+/// \brief Contains boost::typeindex::ctti_type_index class that is constexpr if C++14
+/// constexpr is supported by compiler.
 ///
 /// boost::typeindex::ctti_type_index class can be used as a drop-in replacement
-/// for std::type_index.
+/// for std::type_index or as type index that can output type names at compile time.
 ///
 /// It is used in situations when typeid() method is not available or 
 /// BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY macro is defined.
@@ -100,8 +101,8 @@ inline const detail::ctti_data& ctti_construct() noexcept {
 ///     * static methods type_id<T>(), type_id_with_cvr<T>()
 ///     * comparison operators
 ///
-/// This class produces slightly longer type names, so consider using stl_type_index
-/// in situations when typeid() is working.
+/// This class produces slightly longer type names in C++11 than stl_type_index, see
+/// "Code Bloat" fore more info.
 class ctti_type_index: public type_index_facade<ctti_type_index, detail::ctti_data> {
     const char* data_;
 

--- a/include/boost/type_index/ctti_type_index.hpp
+++ b/include/boost/type_index/ctti_type_index.hpp
@@ -194,7 +194,7 @@ BOOST_CXX14_CONSTEXPR inline const char* ctti_type_index::name() const noexcept 
 
 inline std::size_t ctti_type_index::get_raw_name_length() const noexcept {
 #if defined(BOOST_NO_CXX14_CONSTEXPR)
-    return detail::constexpr_significant_part_length(raw_name() + detail::skip().size_at_end);
+    return detail::constexpr_significant_part_length(raw_name());
 #else
     return std::strlen(raw_name());
 #endif

--- a/include/boost/type_index/ctti_type_index.hpp
+++ b/include/boost/type_index/ctti_type_index.hpp
@@ -86,7 +86,7 @@ inline const detail::ctti_data& ctti_construct() noexcept {
     // value.
     //
     // Alignments are checked in `type_index_test_ctti_alignment.cpp` test.
-    return *reinterpret_cast<const detail::ctti_data*>(boost::detail::ctti<T>::n());
+    return *reinterpret_cast<const detail::ctti_data*>(boost::typeindex::detail::postprocessed_name<T>());
 }
 
 /// \class ctti_type_index
@@ -115,7 +115,7 @@ public:
     using type_info_t = detail::ctti_data;
 
     BOOST_CXX14_CONSTEXPR inline ctti_type_index() noexcept
-        : data_(boost::detail::ctti<void>::n())
+        : data_(boost::typeindex::detail::postprocessed_name<void>())
     {}
 
     inline ctti_type_index(const type_info_t& data) noexcept
@@ -166,14 +166,14 @@ template <class T>
 BOOST_CXX14_CONSTEXPR inline ctti_type_index ctti_type_index::type_id() noexcept {
     using no_ref_t = typename std::remove_reference<T>::type;
     using no_cvr_t = typename std::remove_cv<no_ref_t>::type;
-    return ctti_type_index(boost::detail::ctti<no_cvr_t>::n());
+    return ctti_type_index(boost::typeindex::detail::postprocessed_name<no_cvr_t>());
 }
 
 
 
 template <class T>
 BOOST_CXX14_CONSTEXPR inline ctti_type_index ctti_type_index::type_id_with_cvr() noexcept {
-    return ctti_type_index(boost::detail::ctti<T>::n());
+    return ctti_type_index(boost::typeindex::detail::postprocessed_name<T>());
 }
 
 
@@ -193,13 +193,16 @@ BOOST_CXX14_CONSTEXPR inline const char* ctti_type_index::name() const noexcept 
 }
 
 inline std::size_t ctti_type_index::get_raw_name_length() const noexcept {
-    return std::strlen(raw_name() + detail::skip().size_at_end);
+#if defined(BOOST_NO_CXX14_CONSTEXPR)
+    return detail::constexpr_significant_part_length(raw_name() + detail::skip().size_at_end);
+#else
+    return std::strlen(raw_name());
+#endif
 }
 
 
 inline std::string ctti_type_index::pretty_name() const {
     std::size_t len = get_raw_name_length();
-    while (raw_name()[len - 1] == ' ') --len; // MSVC sometimes adds whitespaces
     return std::string(raw_name(), len);
 }
 

--- a/include/boost/type_index/ctti_type_index.hpp
+++ b/include/boost/type_index/ctti_type_index.hpp
@@ -14,10 +14,11 @@
 /// constexpr is supported by compiler.
 ///
 /// boost::typeindex::ctti_type_index class can be used as a drop-in replacement
-/// for std::type_index or as type index that can output type names at compile time.
+/// for std::type_index or as a type index that works at compile time, can provide a
+/// type name at compile time.
 ///
-/// It is used in situations when typeid() method is not available or 
-/// BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY macro is defined.
+/// It is used as the boost::typeindex::type_index when `typeid()` is not 
+/// available or BOOST_TYPE_INDEX_FORCE_NO_RTTI_COMPATIBILITY macro is defined.
 
 #include <boost/type_index/detail/config.hpp>
 
@@ -94,12 +95,22 @@ inline const detail::ctti_data& ctti_construct() noexcept {
 /// This class is a wrapper that pretends to work exactly like stl_type_index, but does
 /// not require RTTI support. \b For \b description \b of \b functions \b see type_index_facade.
 ///
-/// This class on C++14 compatible compilers has following functions marked as constexpr:
+/// This class on C++14 compatible compilers can be used at compile time and has the following
+/// functions marked as constexpr:
 ///     * default constructor
-///     * copy constructors and assignemnt operations
+///     * copy constructors and assignment operations
 ///     * class methods: name(), before(const ctti_type_index& rhs), equal(const ctti_type_index& rhs)
 ///     * static methods type_id<T>(), type_id_with_cvr<T>()
 ///     * comparison operators
+///
+/// Moreover, starting from C++14 the name() function always outputs the pretty_name() of a
+/// type. For example the following static assert holds:
+/// \code
+/// static_assert(
+///     boost::typeindex::ctti_type_index:::type_id<int>().name()
+///     == std::string_view{"int"}
+/// );
+/// \endcode
 ///
 /// This class produces slightly longer type names in C++11 than stl_type_index, see
 /// "Code Bloat" fore more info.

--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -147,6 +147,20 @@ constexpr ctti_skip skip() noexcept { return detail::make_ctti_skip(0, 0, ""); }
     }
 #endif // defined(BOOST_TYPE_INDEX_DETAIL_IS_CONSTANT)
 
+    BOOST_CXX14_CONSTEXPR BOOST_FORCEINLINE std::size_t constexpr_significant_part_length(const char* str) noexcept {
+        std::size_t length = 0;
+        while (str[length]) {
+            ++length;
+        }
+
+        // MSVC sometimes adds whitespaces
+        while (str[length - 1] == ' ') {
+            --length;
+        }
+
+        return length;
+    }
+
     template<class ForwardIterator1, class ForwardIterator2>
     BOOST_CXX14_CONSTEXPR inline ForwardIterator1 constexpr_search(
         ForwardIterator1 first1,
@@ -208,14 +222,14 @@ constexpr ctti_skip skip() noexcept { return detail::make_ctti_skip(0, 0, ""); }
 
     template <unsigned int ArrayLength>
     BOOST_CXX14_CONSTEXPR inline const char* skip_begining(const char* begin) noexcept {
-        detail::assert_compile_time_legths<(ArrayLength > skip().size_at_begin + skip().size_at_end)>();
-        return skip().until_runtime_length
-            ? detail::skip_begining_runtime<ArrayLength - skip().size_at_begin>(begin + skip().size_at_begin)
-            : begin + skip().size_at_begin
+        detail::assert_compile_time_legths<(ArrayLength > detail::skip().size_at_begin + detail::skip().size_at_end)>();
+        return detail::skip().until_runtime_length
+            ? detail::skip_begining_runtime<ArrayLength - detail::skip().size_at_begin>(begin + detail::skip().size_at_begin)
+            : begin + detail::skip().size_at_begin
         ;
     }
 
-#if !defined(__clang__) && defined(__GNUC__) && !defined(BOOST_NO_CXX14_CONSTEXPR)
+#if !defined(BOOST_NO_CXX14_CONSTEXPR)
     template <unsigned int... I>
     struct index_seq {};
 
@@ -247,8 +261,8 @@ constexpr ctti_skip skip() noexcept { return detail::make_ctti_skip(0, 0, ""); }
 
     template <char... C>
     struct cstring {
-        static constexpr unsigned int size_ = sizeof...(C);
-        static constexpr char data_[size_] = { C... };
+        static constexpr unsigned int size_ = sizeof...(C) + 1;
+        static constexpr char data_[size_] = { C..., '\0' };
     };
 
     template <char... C>
@@ -289,7 +303,8 @@ struct ctti {
 
     template <unsigned int ...Indexes>
     constexpr static const char* impl(::boost::typeindex::detail::index_seq<Indexes...> ) noexcept {
-        return ::boost::typeindex::detail::cstring<s<Indexes>()...>::data_;
+        using string_type = ::boost::typeindex::detail::cstring<s<Indexes>()...>;
+        return string_type::data_;
     }
 
     template <unsigned int D = 0> // `D` means `Dummy`
@@ -313,11 +328,12 @@ struct ctti {
         boost::typeindex::detail::assert_compile_time_legths<
             (size > boost::typeindex::detail::skip().size_at_begin + boost::typeindex::detail::skip().size_at_end + sizeof("const *") - 1)
         >();
-        static_assert(!boost::typeindex::detail::skip().until_runtime_length, "Skipping for GCC in C++14 mode is unsupported");
+        static_assert(!boost::typeindex::detail::skip().until_runtime_length, "Skipping by pettern in C++14 mode is unsupported");
 
         using idx_seq = typename boost::typeindex::detail::make_index_seq_impl<
             boost::typeindex::detail::skip().size_at_begin,
             size - sizeof("const *") + 1 - boost::typeindex::detail::skip().size_at_begin
+            - 1
         >::type;
         return impl(idx_seq());
     }
@@ -347,6 +363,32 @@ struct ctti {
 
 }} // namespace boost::detail
 
+namespace boost { namespace typeindex { namespace detail {
+
+#if !defined(BOOST_NO_CXX14_CONSTEXPR)
+    template <class T, unsigned int ...Indexes>
+    constexpr const char* make_pretty_name(::boost::typeindex::detail::index_seq<Indexes...> ) noexcept {
+        constexpr const char* name = boost::detail::ctti<T>::n();
+        using string_type = ::boost::typeindex::detail::cstring<name[Indexes]...>;
+        return string_type::data_;
+    }
+
+    template <class T>
+    constexpr const char* postprocessed_name() noexcept {
+        constexpr const char* name = boost::detail::ctti<T>::n();
+        constexpr auto length = detail::constexpr_significant_part_length(name + detail::skip().size_at_end);
+        using idx_seq = typename boost::typeindex::detail::make_index_seq_impl<0, length>::type;
+        return boost::typeindex::detail::make_pretty_name<T>(idx_seq());
+    }
+#else
+    template <class T>
+    constexpr const char* postprocessed_name() noexcept {
+        return boost::detail::ctti<T>::n();
+    }
+
+#endif
+
+}}} // namespace boost::typeindex::detail
 
 
 #endif // BOOST_TYPE_INDEX_DETAIL_COMPILE_TIME_TYPE_INFO_HPP

--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -328,7 +328,7 @@ struct ctti {
         boost::typeindex::detail::assert_compile_time_legths<
             (size > boost::typeindex::detail::skip().size_at_begin + boost::typeindex::detail::skip().size_at_end + sizeof("const *") - 1)
         >();
-        static_assert(!boost::typeindex::detail::skip().until_runtime_length, "Skipping by pettern in C++14 mode is unsupported");
+        static_assert(!boost::typeindex::detail::skip().until_runtime_length, "Skipping by pattern in C++14 mode is unsupported");
 
         using idx_seq = typename boost::typeindex::detail::make_index_seq_impl<
             boost::typeindex::detail::skip().size_at_begin,

--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -149,7 +149,7 @@ constexpr ctti_skip skip() noexcept { return detail::make_ctti_skip(0, 0, ""); }
 
     BOOST_CXX14_CONSTEXPR BOOST_FORCEINLINE std::size_t constexpr_significant_part_length(const char* str) noexcept {
         std::size_t length = 0;
-        while (str[length]) {
+        while (str[length + detail::skip().size_at_end]) {
             ++length;
         }
 
@@ -376,7 +376,7 @@ namespace boost { namespace typeindex { namespace detail {
     template <class T>
     constexpr const char* postprocessed_name() noexcept {
         constexpr const char* name = boost::detail::ctti<T>::n();
-        constexpr auto length = detail::constexpr_significant_part_length(name + detail::skip().size_at_end);
+        constexpr auto length = detail::constexpr_significant_part_length(name);
         using idx_seq = typename boost::typeindex::detail::make_index_seq_impl<0, length>::type;
         return boost::typeindex::detail::make_pretty_name<T>(idx_seq());
     }

--- a/include/boost/type_index/detail/compile_time_type_info.hpp
+++ b/include/boost/type_index/detail/compile_time_type_info.hpp
@@ -44,25 +44,25 @@ namespace boost { namespace typeindex { namespace detail {
     struct ctti_skip {
         std::size_t size_at_begin;
         std::size_t size_at_end;
-        const char* until_runtime;
-        std::size_t until_runtime_length;
+        const char* substrig;
+        std::size_t substrig_length;
     };
 
     template <std::size_t N>
     constexpr ctti_skip make_ctti_skip(std::size_t size_at_begin,
                                        std::size_t size_at_end,
-                                       bool more_at_runtime,
-                                       const char (&until_runtime)[N])
+                                       bool is_skip_by_substring,
+                                       const char (&substrig)[N])
     {
-        return ctti_skip{size_at_begin, size_at_end, until_runtime, more_at_runtime ? N - 1 : 0};
+        return ctti_skip{size_at_begin, size_at_end, substrig, is_skip_by_substring ? N - 1 : 0};
     }
 
     template <std::size_t N>
     constexpr ctti_skip make_ctti_skip(std::size_t size_at_begin,
                                        std::size_t size_at_end,
-                                       const char (&until_runtime)[N])
+                                       const char (&substrig)[N])
     {
-        return ctti_skip{size_at_begin, size_at_end, until_runtime, N - 1};
+        return ctti_skip{size_at_begin, size_at_end, substrig, N - 1};
     }
 
 #if defined(BOOST_TYPE_INDEX_DOXYGEN_INVOKED)
@@ -211,20 +211,20 @@ constexpr ctti_skip skip() noexcept { return detail::make_ctti_skip(0, 0, ""); }
     }
 
     template <unsigned int ArrayLength>
-    BOOST_CXX14_CONSTEXPR inline const char* skip_begining_runtime(const char* begin) noexcept {
-        constexpr auto skip_value = detail::skip();  // to have the same `.until_runtime` value in code below
+    BOOST_CXX14_CONSTEXPR inline const char* after_substrig(const char* begin) noexcept {
+        constexpr auto skip_value = detail::skip();  // to have the same `.substrig` value in code below
         const char* const it = detail::constexpr_search(
             begin, begin + ArrayLength,
-            skip_value.until_runtime, skip_value.until_runtime + skip_value.until_runtime_length
+            skip_value.substrig, skip_value.substrig + skip_value.substrig_length
         );
-        return (it == begin + ArrayLength ? begin : it + skip_value.until_runtime_length);
+        return (it == begin + ArrayLength ? begin : it + skip_value.substrig_length);
     }
 
     template <unsigned int ArrayLength>
     BOOST_CXX14_CONSTEXPR inline const char* skip_begining(const char* begin) noexcept {
         detail::assert_compile_time_legths<(ArrayLength > detail::skip().size_at_begin + detail::skip().size_at_end)>();
-        return detail::skip().until_runtime_length
-            ? detail::skip_begining_runtime<ArrayLength - detail::skip().size_at_begin>(begin + detail::skip().size_at_begin)
+        return detail::skip().substrig_length
+            ? detail::after_substrig<ArrayLength - detail::skip().size_at_begin>(begin + detail::skip().size_at_begin)
             : begin + detail::skip().size_at_begin
         ;
     }
@@ -309,6 +309,7 @@ struct ctti {
 
     template <unsigned int D = 0> // `D` means `Dummy`
     constexpr static const char* n() noexcept {
+        namespace tid = boost::typeindex::detail;
     #if defined(BOOST_TYPE_INDEX_FUNCTION_SIGNATURE)
         constexpr unsigned int size = sizeof(BOOST_TYPE_INDEX_FUNCTION_SIGNATURE);
     #elif defined(__FUNCSIG__)
@@ -322,18 +323,21 @@ struct ctti {
                     || defined(__DMC__)
         constexpr unsigned int size = sizeof(__PRETTY_FUNCTION__);
     #else
-        boost::typeindex::detail::failed_to_get_function_name<T>();
+        tid::failed_to_get_function_name<T>();
     #endif
 
-        boost::typeindex::detail::assert_compile_time_legths<
-            (size > boost::typeindex::detail::skip().size_at_begin + boost::typeindex::detail::skip().size_at_end + sizeof("const *") - 1)
+        tid::assert_compile_time_legths<
+            (size > tid::skip().size_at_begin + tid::skip().size_at_end + sizeof("const *") - 1)
         >();
-        static_assert(!boost::typeindex::detail::skip().until_runtime_length, "Skipping by pattern in C++14 mode is unsupported");
+        static_assert(
+            !tid::skip().substrig_length,
+            "Skipping by substring for GCC in C++14 mode is unsupported"
+        );
 
-        using idx_seq = typename boost::typeindex::detail::make_index_seq_impl<
-            boost::typeindex::detail::skip().size_at_begin,
-            size - sizeof("const *") + 1 - boost::typeindex::detail::skip().size_at_begin
-            - 1
+        using idx_seq = typename tid::make_index_seq_impl<
+            tid::skip().size_at_begin,
+            size - (sizeof("const *") - 1) - tid::skip().size_at_begin
+            - 1 /* detail::cstring adds a terminating '\0' */
         >::type;
         return impl(idx_seq());
     }

--- a/test/type_index_constexpr_test.cpp
+++ b/test/type_index_constexpr_test.cpp
@@ -157,8 +157,8 @@ void constexpr_known_names_test() {
 void not_constexpr_known_names_test() {
     using boost::typeindex::ctti_type_index;
 
-    BOOST_TEST_EQ(std::string(ctti_type_index::type_id<int>().pretty_name()), "int");
-    BOOST_TEST_EQ(std::string(ctti_type_index::type_id<void>().pretty_name()), "void");
+    BOOST_TEST_EQ(ctti_type_index::type_id<int>().pretty_name(), "int");
+    BOOST_TEST_EQ(ctti_type_index::type_id<void>().pretty_name(), "void");
 }
 
 int main() {

--- a/test/type_index_constexpr_test.cpp
+++ b/test/type_index_constexpr_test.cpp
@@ -147,11 +147,29 @@ void constexpr_test() {
 #endif // #if !defined(_MSC_VER) || _MSC_VER > 1916
 }
 
+void constexpr_known_names_test() {
+    using boost::typeindex::ctti_type_index;
+
+    BOOST_TEST_EQ(std::string(ctti_type_index::type_id<int>().name()), "int");
+    BOOST_TEST_EQ(std::string(ctti_type_index::type_id<void>().name()), "void");
+}
+
+void not_constexpr_known_names_test() {
+    using boost::typeindex::ctti_type_index;
+
+    BOOST_TEST_EQ(std::string(ctti_type_index::type_id<int>().pretty_name()), "int");
+    BOOST_TEST_EQ(std::string(ctti_type_index::type_id<void>().pretty_name()), "void");
+}
 
 int main() {
     strcmp_same();
     search_same();
     constexpr_test();
+#if !defined(BOOST_NO_CXX14_CONSTEXPR)
+    constexpr_known_names_test();
+#else
+    not_constexpr_known_names_test();
+#endif
     return boost::report_errors();
 }
 


### PR DESCRIPTION
Also reduce binary sizes and improve the documentation.

Fixes: https://github.com/boostorg/type_index/issues/45